### PR TITLE
fix: use python from ``$PATH`` rather than hard written path.

### DIFF
--- a/git-deps
+++ b/git-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # git-deps - automatically detect dependencies between git commits
 # Copyright (C) 2013 Adam Spiers <git@adamspiers.org>


### PR DESCRIPTION
This allows to use ``git-deps`` in a virtualenv for instance.