### PR TITLE
Allow git-deps server to be bound to external IP address

### DIFF
--- a/git-deps
+++ b/git-deps
@@ -767,7 +767,7 @@ def serve(options):
               "insecure!")
         print("!! Arbitrary code can be executed from browser!")
         print()
-    webserver.run(port=options.port, debug=options.debug)
+    webserver.run(host='0.0.0.0', port=options.port, debug=options.debug)
 
 
 def main():


### PR DESCRIPTION
This issue rised trying to create a Dockerfile containing all necessary stuff to run the latest master of git-deps (see https://github.com/paulwellnerbou/git-deps-docker)