### PR TITLE
Skip checking dependencies for merge commits

### DIFF
--- a/git-deps.py
+++ b/git-deps.py
@@ -390,6 +390,7 @@ class DependencyDetector(object):
         self.todo_d[dependent.hex] = True
 
         while self.todo:
+            count = 0
             sha1s = [commit.hex[:8] for commit in self.todo]
             self.logger.debug("TODO list: %s" % " ".join(sha1s))
             dependent = self.todo.pop(0)
@@ -397,6 +398,14 @@ class DependencyDetector(object):
             self.logger.debug("Processing %s from TODO list" %
                               dependent.hex[:8])
             self.notify_listeners('new_commit', dependent)
+
+            for parent in dependent.parents:
+                count = count + 1
+
+            # If a commit has more than one parent it is a merge commit
+            # Skip checking dependencies for merge commits
+            if count > 1:
+                continue
 
             for parent in dependent.parents:
                 self.find_dependencies_with_parent(dependent, parent)


### PR DESCRIPTION
When git-deps is run to find any dependent commits in linux kernel there is a chance it encounters 'merge' commits. git-deps output is very huge when it checks dependency for 'merge' commits and git-deps needs to be stopped manually since it runs for a very long time.

This commit checks if a git commit has a more than one parent ie. merge commit and skips checking the dependencies.
