### PR TITLE
Explicitly require python2

### DIFF
--- a/git-deps.py
+++ b/git-deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # git-deps - automatically detect dependencies between git commits
 # Copyright (C) 2013 Adam Spiers <git@adamspiers.org>


### PR DESCRIPTION
Some distributions (e.g. Arch Linux) switched to python3 as the default python interpreter, this changes git-deps to explicitly require python2 (and thus work with Arch Linux ootb).