### PR TITLE
Add .snapcraft.yaml which will produce a strict snap for CLI use

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -1,0 +1,25 @@
+name: git-deps
+version: 0.1
+summary: A tool for performing analysis of dependencies between git commits
+description: |
+    git-deps is a tool for performing automatic analysis of dependencies
+    between commits in a git repository.
+
+confinement: strict
+
+apps:
+    git-deps:
+        command: git-deps/git-deps.py
+        plugs:
+            - home
+
+parts:
+    git-deps:
+        plugin: copy
+        source: .
+        files:
+            .: git-deps
+        stage-packages:
+            - git
+            - python2.7
+            - python-pygit2


### PR DESCRIPTION
This snapcraft.yaml builds a snap package which can be installed in strict mode, with access to a user's home directory permitted.

(See http://snapcraft.io/ for more details about snaps.)