### PR TITLE
Fix noty depdendency to 2.4.1, version 3 is incompatible.

### DIFF
--- a/html/package.json
+++ b/html/package.json
@@ -29,7 +29,7 @@
         "d3": "~3.5.3",
         "webcola": "aspiers/WebCola#git-deps-master",
         "jquery": "~2.1.3",
-        "noty": "needim/noty",
+        "noty": "~v2.4.1",
         "browserify": "*",
         "coffeeify" : "~1.0.0",
         "dagre": "~0.7.1"


### PR DESCRIPTION
Fix noty dependency in package.json to 2.4.1, as the current version 3 is incompatible