### PR TITLE
General testing improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: python
+matrix:
+  include:
+  - python: 2.7
+    env: TOX_ENV=flake8
+  - python: 2.7
+    env: TOX_ENV=py27
+  - python: 3.4
+    env: TOX_ENV=py34
+  - python: 3.6
+    env: TOX_ENV=py36
+install:
+- pip install tox
+script:
+- tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist = py27,py34,flake8
 skip_missing_interpreters = True
 
 [testenv]
+usedevelop = True
 changedir = tests
 commands =
     py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 1.8
-envlist = py27,py34,flake8
+envlist = py27,py34,py36,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Recreating the sdist tarball takes some time when calling tox. So skip
the sdist creation (which will be implicitly done when
"usedevelop=True" is set) and do the "setup.py develop" step instead
which is recommended in the tox documentation[1].

[1]
http://tox.readthedocs.io/en/latest/example/general.html#avoiding-expensive-sdist