### PR TITLE
add git-fixup and documentation for use case

### DIFF
--- a/bin/git-fixup
+++ b/bin/git-fixup
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if ! git commit -m 'fixup commit'; then
+    echo >&2 "Failed to create fixup commit; aborting."
+    exit 1
+fi
+
+deps=( $( git deps HEAD^! ) )
+if [ ${#deps[@]} != 1 ]; then
+    echo >&2 "Failed to find a single dependency of the fixup commit; aborting."
+    git reset --soft HEAD^
+    exit 1
+fi
+
+git commit --amend --fixup=$deps
+
+# TODO: support optionally triggering the rebase.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ console_scripts =
     gitfile-handler = git_deps.handler:run
 
 [files]
+scripts =
+    bin/git-fixup
 packages =
     git_deps
 data_files =


### PR DESCRIPTION
This is a nice new use case for git-deps which makes it even easier to amend commits buried in the history.