### PR TITLE
Don't crash with commit messages that aren't valid utf-8

### DIFF
--- a/git_deps/gitutils.py
+++ b/git_deps/gitutils.py
@@ -55,7 +55,11 @@ class GitUtils(object):
 
     @classmethod
     def oneline(cls, commit):
-        return commit.message.split('\n', 1)[0]
+        try:
+            ret = commit.message.split('\n', 1)[0]
+        except UnicodeDecodeError:
+            ret = "Invalid utf-8 commit message"
+        return ret
 
     @classmethod
     def commit_summary(cls, commit):


### PR DESCRIPTION
WIne is old and has imported the CVS and pre-CVS commits too.
There are commits with messages that aren't utf-8 and git deps crashes on those.
As the commit message oneliner is used just for debugs I've chosen the simple way out instead of trying to convert the commit message to a byte stream and work on that.

To reproduce:

```
git clone git://source.winehq.org/git/wine.git
git deps 9b9f97e3f668c9d291b4f9fa2944ddb11509970f^..9b9f97e3f668c9d291b4f9fa2944ddb11509970f
114a31a2a8cd6f97cceae752aaf65a36e9dda271
0799c1a7801d03bd88d616c44a5ac30690f48519
17216f56370fb0499e024a44570e59c198b47626
6790cdb8f5c8d15df0b19702e36e888c996fc97c
767e6f6f9d4fae5694c8731b93ce74fca26f732e
Traceback (most recent call last):
  File "/home/michi/.local/bin/git-deps", line 10, in <module>
    sys.exit(run())
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/cli.py", line 144, in run
    main(sys.argv[1:])
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/cli.py", line 138, in main
    cli(options, args)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/cli.py", line 122, in cli
    detector.find_dependencies(rev)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/detector.py", line 122, in find_dependencies
    self.find_dependencies_with_parent(dependent, parent)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/detector.py", line 147, in find_dependencies_with_parent
    self.blame_diff_hunk(dependent, parent, path, hunk)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/detector.py", line 175, in blame_diff_hunk
    path, line, line_to_culprit)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/detector.py", line 202, in process_hunk_line
    path, line_num)
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/detector.py", line 263, in process_new_dependency
    GitUtils.oneline(dependency)))
  File "/home/michi/.local/lib/python2.7/site-packages/git_deps/gitutils.py", line 58, in oneline
    return commit.message.split('\n', 1)[0]
UnicodeDecodeError: 'utf8' codec can't decode byte 0xf6 in position 7134: invalid start byte
```