### PR TITLE
Fix ValueError:can't have unbuffered text I/O (fixes #87)

### DIFF
--- a/git_deps/cli.py
+++ b/git_deps/cli.py
@@ -135,7 +135,7 @@ def main(args):
     if options.serve:
         serve(options)
     else:
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')
         try:
             cli(options, args)
         except InvalidCommitish as e:


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "/usr/bin/git-deps", line 10, in <module>
    sys.exit(run())
  File "/usr/lib/python3.7/site-packages/git_deps/cli.py", line 146, in run
    main(sys.argv[1:])
  File "/usr/lib/python3.7/site-packages/git_deps/cli.py", line 138, in main
    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
  File "/usr/lib64/python3.7/os.py", line 1026, in fdopen
    return io.open(fd, *args, **kwargs)
ValueError: can't have unbuffered text I/O