### PR TITLE
Don't totally ignore KeyboardInterrupt

### DIFF
--- a/git_deps/cli.py
+++ b/git_deps/cli.py
@@ -122,7 +122,7 @@ def cli(options, args):
             try:
                 detector.find_dependencies(rev)
             except KeyboardInterrupt:
-                pass
+                break
 
     if options.json:
         print(json.dumps(listener.json(), sort_keys=True, indent=4))


### PR DESCRIPTION
~~**UNTESTED**: can't test until #87 is resolved (hopefully by #93).~~

This *should* revert commit 2a05400e232e14f0d4c1cbfb548a0871ea57bd44.  I have no idea why I did that, but if the reason emerges after the revert, we should address it in some other more sensible way.

Fixes #83 and #89.