### PR TITLE
Drop setuptools-markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ virt: lxd
 language: python
 matrix:
   include:
-  - python: 3.6
-    env: TOX_ENV=py36
   - python: 3.7
     env: TOX_ENV=py37
   - python: 3.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,9 +11,8 @@ Before you pick an option, it is very important to consider that [only
 certain combinations of libgit2 and pygit2 will work
 together](http://www.pygit2.org/install.html#version-numbers).
 
-Also, Python 2.x is no longer supported for `git-deps`, although as of
-April 2021 it may still work if you are lucky and know what you are
-doing.
+Also, Python < 3.7 is no longer supported for `git-deps` (since pygit2
+requires 3.7 or higher).
 
 ## Option 0 (easiest): let `pip` take care of everything
 

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def setup_package():
         setup_requires=[
             'six',
             'pyscaffold>=2.5.10,<2.6a0',
-            'setuptools-markdown',
         ] + sphinx,
-        long_description_markdown_filename='README.md',
+        long_description='README.md',
+        long_description_content_type="text/markdown",
         use_pyscaffold=True
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 1.8
-envlist = py36,py37,py38,flake8
+envlist = py37,py38,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Stop using setuptools-markdown which is no longer maintained and
doesn't work anymore. Instead use the long_description_content_type
variable (see [0]) to indicate that the given long_description is in
markdown format.

This fixes:

AttributeError: module 'pypandoc' has no attribute 'convert'

[0] https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/

Fixes #112