### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ virt: lxd
 language: python
 matrix:
   include:
-  - python: 3.6
-    env: TOX_ENV=py36
   - python: 3.7
     env: TOX_ENV=py37
   - python: 3.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,9 +11,8 @@ Before you pick an option, it is very important to consider that [only
 certain combinations of libgit2 and pygit2 will work
 together](http://www.pygit2.org/install.html#version-numbers).
 
-Also, Python 2.x is no longer supported for `git-deps`, although as of
-April 2021 it may still work if you are lucky and know what you are
-doing.
+Also, Python < 3.7 is no longer supported for `git-deps` (since pygit2
+requires 3.7 or higher).
 
 ## Option 0 (easiest): let `pip` take care of everything
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 1.8
-envlist = py36,py37,py38,flake8
+envlist = py37,py38,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
These days pygit2 requires Python >= 3.7:

https://pypi.org/project/pygit2/

So reluctantly drop support for 3.6.  If anyone can figure out a way
of bringing it back (e.g. via using old versions of pygit2 where
necessary), we could consider doing that.