### PR TITLE
Detect new files in diffs (fix -L invalid line number: 0)

### DIFF
--- a/git_deps/detector.py
+++ b/git_deps/detector.py
@@ -144,6 +144,9 @@ class DependencyDetector(object):
         diff = self.repo.diff(parent, dependent,
                               context_lines=self.options.context_lines)
         for patch in diff:
+            if patch.delta.old_file.mode == 0:
+                self.logger.info("      New file %s, no old hunks" % patch.delta.new_file.path)
+                continue
             path = patch.delta.old_file.path
             self.logger.info("      Examining hunks in %s" % path)
             for hunk in patch.hunks:
@@ -342,6 +345,7 @@ class DependencyDetector(object):
         tree only contains entries for the directory it refers to, not
         recursively for all subdirectories.
         """
+        self.logger.debug("        tree_lookup %s in %s" % (target_path, commit))
         segments = target_path.split("/")
         tree_or_blob = commit.tree
         path = ''


### PR DESCRIPTION
New files in patch are shown as

	diff --git a/git_deps/blame.py b/git_deps/blame.py
	new file mode 100644
	index 0000000..41d79fe
	--- /dev/null
	+++ b/git_deps/blame.py
	@@ -0,0 +1,61 @@

This is even visible in pygit2.Diff.patch.
However, when you look at the same diff's
pygit2.Patch.delta.old_file.path it is not '/dev/null' but 'git_deps/blame.py'. This could have been caught up by tree_lookup() in blame_diff_hunk if '/dev/null' was checked. Because old_file.path is a valid filename though, tree_lookup() may succeed. When? Consider case of moving a file and replacing it with a symlink:

	diff --git a/some-script b/some-script
	deleted file mode 100755
	index 21c9f09..0000000
	--- a/some-script
	+++ /dev/null
	@@ -1,3 +0,0 @@  <-- git-deps examines this hunk
	-#!/usr/bin/perl
	-...
	-

	diff --git a/some-script b/some-script
	new file mode 120000
	index 0000000..0098051
	--- /dev/null
	+++ b/some-script
	@@ -0,0 +1 @@  <-- this can be skipped, new file
	+newdir/some-script

As a fix look at file mode of each Patch.delta's file and detect new files from old_file.mode, new files don't bring about any deps so they can be skipped in hunk examination.

Without the fix crash like below happes:
	fatal: -L invalid line number: 0
	subprocess.CalledProcessError: Command '['git', 'blame', '--porcelain', '-L', '0,+0', 'abcde', '--', 'some-script']' returned non-zero exit status 128.

Fixes #41
Ref #108