### PR TITLE
chore: modernize setup infrastructure

### DIFF
--- a/git_deps/__init__.py
+++ b/git_deps/__init__.py
@@ -1,6 +1,1 @@
-import pkg_resources
-
-try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
+__version__ = '1.1.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,13 @@
 [metadata]
 name = git-deps
+version = attr: git_deps.__version__
 summary = automatically detect dependencies between git commits
 author = Adam Spiers
 author_email = git@adamspiers.org
 license = GPL-2+
 home_page = https://github.com/aspiers/git-deps
-description_file = README.md
+long_description = file: README.md
+long_description_content_type = text/markdown
 classifier =
     Development Status :: 4 - Beta
     Environment :: Console
@@ -33,6 +35,7 @@ data_files =
 [options]
 packages =
     git_deps
+requires = Sphinx
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ data_files =
 
 [options]
 packages =
-    git_deps
+    find:
 requires = Sphinx
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-    Setup file for git_deps.
-
-    This file was generated with PyScaffold, a tool that easily
-    puts up a scaffold for your new Python project. Learn more under:
-    http://pyscaffold.readthedocs.org/
-"""
-
-import sys
 from setuptools import setup
 
 
-def setup_package():
-    needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
-    sphinx = ['sphinx'] if needs_sphinx else []
-    setup(
-        setup_requires=[
-            'pyscaffold',
-        ] + sphinx,
-        long_description='README.md',
-        long_description_content_type="text/markdown",
-        use_pyscaffold=True
-    )
-
-
-if __name__ == "__main__":
-    setup_package()
+setup()

--- a/tests/create-repo.sh
+++ b/tests/create-repo.sh
@@ -10,7 +10,6 @@ two
 three
 four
 five
-six
 seven
 eight
 nine


### PR DESCRIPTION
* it seems to me that moving from the procedural `setup.py` to the declarative `setup.cfg` is a nice compromise between modernization and compatibility with legacy systems
* `pkg_resources` are dead, we should not use them, the suggested construct has as The Single Source of Truth™ version in `git_deps/__init__.py`, and it should work anywhere with `setuptools` >= 46.4.0, which is reasonably ancient
* `six` should really never be mentioned any more